### PR TITLE
Add test for invalidate cache success 

### DIFF
--- a/unittests/Basic/FileManagerTest.cpp
+++ b/unittests/Basic/FileManagerTest.cpp
@@ -6,7 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#define private public
 #include "clang/Basic/FileManager.h"
+#undef private
 #include "clang/Basic/FileSystemOptions.h"
 #include "clang/Basic/FileSystemStatCache.h"
 #include "llvm/ADT/STLExtras.h"
@@ -109,7 +111,6 @@ TEST_F(FileManagerTest, invalidateCacheSuccess) {
   manager.InvalidateCache(NULL);
 
   manager.InvalidateCache(*file);
-  // TODO: FileEntriesToRead is private member variable of class FileManager
   ASSERT_TRUE(manager.FileEntriesToReread);
 
   ASSERT_FALSE((*file)->isValid());

--- a/unittests/Basic/FileManagerTest.cpp
+++ b/unittests/Basic/FileManagerTest.cpp
@@ -98,6 +98,23 @@ class FileManagerTest : public ::testing::Test {
   FileManager manager;
 };
 
+// If file entry valid, mark the file entry invalid, until reread.
+TEST_F(FileManagerTest, invalidateCacheSuccess) {
+  manager.setStatCache(std::make_unique<FakeStatCache>());
+
+  manager.getVirtualFile("file.cpp", 100, 0);
+  auto file = manager.getFile("file.cpp");
+
+  // Check for file null assertion success
+  manager.InvalidateCache(NULL);
+
+  manager.InvalidateCache(*file);
+  // TODO: FileEntriesToRead is private member variable of class FileManager
+  ASSERT_TRUE(manager.FileEntriesToReread);
+
+  ASSERT_FALSE((*file)->isValid());
+}
+
 // When a virtual file is added, its getDir() field is set correctly
 // (not NULL, correct name).
 TEST_F(FileManagerTest, getVirtualFileSetsTheDirFieldCorrectly) {

--- a/unittests/Basic/SourceManagerTest.cpp
+++ b/unittests/Basic/SourceManagerTest.cpp
@@ -9,7 +9,9 @@
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/DiagnosticOptions.h"
+#define private public
 #include "clang/Basic/FileManager.h"
+#undef private
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Basic/TargetOptions.h"
@@ -66,7 +68,6 @@ TEST_F(SourceManagerTest, invalidateCacheSuccess) {
   SourceMgr::invalidateCache(mainFileID);
 
   EXPECT_FALSE(SrcMgr::ContentCache);
-  // TODO: Getter or not? Recently added.
   EXPECT_TRUE(SourceFile->FileEntriesToReread);
   EXPECT_FALSE(SourceFile->isValid());
 }


### PR DESCRIPTION
Ref https://github.com/vgvassilev/clang/commit/6ffdac0df994b96f3992b05523007c3ebc712a86.
- [x] File Manager
- [x] Source Manager
- [x] Handling check for `FileEntriesToReread`. (private + recent: ref https://github.com/vgvassilev/clang/commit/d6889e8a27061e93f12cc53315d0c51ed41340ad)

Ref: https://github.com/vgvassilev/clang/pull/1#discussion_r867521452.